### PR TITLE
Refine IP Address functionality

### DIFF
--- a/fetch_ip.sh
+++ b/fetch_ip.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Utility to display IP Addresses
+
+print_default_addresses()
+{
+        # Fetch default gateway device
+        # my_default_dev=$(ip route | grep -P "^default" | perl -p -e '@out = split /dev/,$_; print $out[1]' | cut -d' ' -f2 | head -n 1)
+
+        # Fetch all associated addresses
+        ip_listing=$(hostname -I)
+
+        # Filter them by dotted-decimal/hexquad representation
+        v4_address=$(echo $ip_listing | tr ' ' '\n' | grep "\.")
+        v6_address=$(echo $ip_listing | tr ' ' '\n' | grep "\:")
+
+        # Display them
+        if [[ $v4_address ]]; then
+                echo "$(echo $v4_address | tr ' ' '\n' | sort | uniq | perl -pe 's/^/🌐 IPv4 Address: /')"
+        fi
+
+        if [[ $v6_address ]]; then
+                echo "$(echo $v6_address | tr ' ' '\n' | sort | uniq | perl -pe 's/^/🌐 IPv6 Address: /')"
+        fi
+
+        # Fallback if none found
+        if [[ ! $v4_address && ! $v6_address ]]; then
+                echo "🌐❌ IP Addresses Unavailable"
+        fi
+}

--- a/system_info.sh
+++ b/system_info.sh
@@ -2,6 +2,7 @@
 
 # System Info Script
 # Author: Nickolas Torres
+. ./fetch_ip.sh
 
 echo "----------------------------------------"
 echo "📛 Hostname: $(hostname)"
@@ -11,6 +12,7 @@ echo "🧠 Memory Usage:"
 free -h
 echo "💽 Disk Usage:"
 df -h | grep '^/dev'
-echo "🌐 IP Address: $(hostname -I | awk '{print $1}')"
+#echo "🌐 IP Address: $(hostname -I | awk '{print $1}')"
+print_default_addresses
 echo "📦 OS Version: $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"')"
 echo "----------------------------------------"


### PR DESCRIPTION
This makes the following refinements to the IP address fetch sequence:
- Differentiate between IPv4 and IPv6 addresses.
- Eliminate duplicates (such as an IF with a /32 and /24 version of the address) ⚠️ this can exist, legitimately with namespaces/vrfs but is uncommon.
- Explicitly Identify the case where there are no publicly reachable IP addresses.